### PR TITLE
refractor: api

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,22 @@ bread-tags is a minimal, customizable, fast tas parser for discord bots.
 # Usage
 ```go
 // This code assumes you have defined it in a main/similar function
-parser := Parser{}
 context := make(map[string]interface{})
 context["args"] = []string{"Ice"}
-parser.Parse("Hi, {args}", context) // Hi, Ice
+breadtags.Parse("Hi, {args}", context) // Hi, Ice
 ```
 
 # Creating custom tags
 ```go
 // Create the tag
-tag := &Tag{
+tag := &breadtags.Tag{
 	Name: "mytag",
 	Run: func (value string, context map[string]interface{}) string {
 		// What to do when the tag is ran
 		return value
 	}
 }
-_, err := parser.LoadTag(tag)
-if err != nil {
-	log.Printf("Failed to load tag: %s", tag.Name)
-}
+breadtags.LoadTags(tag)
 // Using the tag
-parser.Parse("{mytag:Some value}", nil) // Some value
+breadtags.Parse("{mytag:Some value}", nil) // Some value
 ```

--- a/parser_test.go
+++ b/parser_test.go
@@ -6,22 +6,22 @@ import (
 )
 
 func TestParser(t *testing.T) {
-	parser := Parser{}
 	t.Run("args", func(t *testing.T) {
 		expected := "a b c"
 		context := make(map[string]interface{})
 		context["args"] = []string{"a", "b", "c"}
-		result := parser.Parse("{args}", context)
+		result := Parse("{args}", context)
 		if result != expected {
 			t.Errorf("Test failed, expected %s, got %s", expected, result)
 		}
 	})
+
 	t.Run("args with joiner", func(t *testing.T) {
 		expected := "a;b;c"
 		context := make(map[string]interface{})
 		context["args"] = []string{"a", "b", "c"}
 		context["joiner"] = ";"
-		result := parser.Parse("{args}", context)
+		result := Parse("{args}", context)
 		if result != expected {
 			t.Errorf("Test failed, expected %s, got %s", expected, result)
 		}
@@ -30,28 +30,28 @@ func TestParser(t *testing.T) {
 		expected := "a b c"
 		context := make(map[string]interface{})
 		context["args"] = []string{"a", "b", "c"}
-		result := parser.Parse("{allargs}", context)
+		result := Parse("{allargs}", context)
 		if result != expected {
 			t.Errorf("Test failed, expected %s, got %s", expected, result)
 		}
 	})
 	t.Run("capitalize", func(t *testing.T) {
 		expected := "Abc"
-		result := parser.Parse("{capitalize:abc}", nil)
+		result := Parse("{capitalize:abc}", nil)
 		if result != expected {
 			t.Errorf("Test failed, expected %s, got %s", expected, result)
 		}
 	})
 	t.Run("uppercase", func(t *testing.T) {
 		expected := "HI"
-		result := parser.Parse("{uppercase:HI}", nil)
+		result := Parse("{uppercase:HI}", nil)
 		if result != expected {
 			t.Errorf("Test failed, expected %s, got %s", expected, result)
 		}
 	})
 	t.Run("uppercase with text", func(t *testing.T) {
 		expected := "Hi, USER"
-		result := parser.Parse("Hi, {uppercase:User}", nil)
+		result := Parse("Hi, {uppercase:User}", nil)
 		if result != expected {
 			t.Errorf("Test failed, expected %s, got %s", expected, result)
 		}
@@ -63,10 +63,10 @@ func TestParser(t *testing.T) {
 		},
 		Aliases: []string{"emptystr"},
 	}
-	parser.LoadTags(emptyString)
+	LoadTags(emptyString)
 	t.Run("empty string", func(t *testing.T) {
 		expected := ""
-		result := parser.Parse("{emptystring}", nil)
+		result := Parse("{emptystring}", nil)
 		if result != expected {
 			t.Errorf("Test failed, expected nothing, got %s", result)
 		}
@@ -74,12 +74,11 @@ func TestParser(t *testing.T) {
 }
 
 func BenchmarkParser(b *testing.B) {
-	parser := Parser{}
 	b.Run("args", func(b *testing.B) {
 		context := make(map[string]interface{})
 		context["args"] = []string{"a", "b", "c"}
 		for i := 0; i < b.N; i++ {
-			parser.Parse("{args}", context)
+			Parse("{args}", context)
 		}
 	})
 	b.Run("args with joiner", func(b *testing.B) {
@@ -87,17 +86,17 @@ func BenchmarkParser(b *testing.B) {
 		context["args"] = []string{"a", "b", "c"}
 		context["joiner"] = ";"
 		for i := 0; i < b.N; i++ {
-			parser.Parse("{args}", context)
+			Parse("{args}", context)
 		}
 	})
 	b.Run("capitalize", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			parser.Parse("{capitalize:abc}", nil)
+			Parse("{capitalize:abc}", nil)
 		}
 	})
 	b.Run("uppercase", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			parser.Parse("{uppercase:abc}", nil)
+			Parse("{uppercase:abc}", nil)
 		}
 	})
 	b.Run("load tag", func(b *testing.B) {
@@ -108,7 +107,7 @@ func BenchmarkParser(b *testing.B) {
 					return ""
 				},
 			}
-			parser.LoadTag(tag)
+			LoadTags(tag)
 		}
 	})
 }


### PR DESCRIPTION
* Changes API. Removes the redundant parser struct and make all methods flat.
* Fix the choose tag
* Add a common LoadTags func for loading all tags at once.